### PR TITLE
Check if the folder exists in WrappedGitRepo cleanup

### DIFF
--- a/src/albs_common_lib/utils/git_utils.py
+++ b/src/albs_common_lib/utils/git_utils.py
@@ -724,12 +724,13 @@ class WrappedGitRepo:
 
     @staticmethod
     def cleanup_on_error(repo_dir):
-        for item in os.listdir(repo_dir):
-            item_path = os.path.join(repo_dir, item)
-            if os.path.isdir(item_path):
-                shutil.rmtree(item_path)
-            else:
-                os.remove(item_path)
+        if os.path.exists(repo_dir):
+            for item in os.listdir(repo_dir):
+                item_path = os.path.join(repo_dir, item)
+                if os.path.isdir(item_path):
+                    shutil.rmtree(item_path)
+                else:
+                    os.remove(item_path)
 
     @staticmethod
     def clone_from(

--- a/src/albs_common_lib/utils/spec_parser.py
+++ b/src/albs_common_lib/utils/spec_parser.py
@@ -301,7 +301,7 @@ class RPMHeaderWrapper():
                 ChangelogRecord(
                     datetime.date.fromtimestamp(date),
                     to_unicode(packager),
-                    [to_unicode(i) for i in text.decode('utf-8').split("\n")],
+                    [to_unicode(i) for i in text.split("\n")],
                 )
             )
         return changelogs


### PR DESCRIPTION
Cloning a repository might fail for different reasons, one of them is when the remote repository does not exist. In such case, it does not make sense to do any cleanup, because the folder simply does not exist.

When this happens, `FileNotFoundError` is raised, which does not clearly represents the real error behind.

Applying this change will skip the cleanup if the folder does not exist, and the operation will end up failing and providing the real error at the end when all attempts are done.